### PR TITLE
Hyphenated fix

### DIFF
--- a/field.go
+++ b/field.go
@@ -40,7 +40,11 @@ func goField(jf string) string {
 			c = unicode.ToUpper(c)
 			mkUpper = false
 		}
-		if c == '_' {
+		switch c {
+		case '_':
+			mkUpper = true
+			continue
+		case '-':
 			mkUpper = true
 			continue
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -20,6 +20,9 @@ var testFiles = []testFile{
 	{
 		path: "testdata/gotimer.json",
 	},
+	{
+		path: "testdata/hyphenated.json",
+	},
 }
 
 func TestReflect(t *testing.T) {

--- a/testdata/hyphenated.json
+++ b/testdata/hyphenated.json
@@ -1,0 +1,3 @@
+{
+  "search-history": "http://google.com/history"
+}

--- a/testdata/hyphenated.json.want
+++ b/testdata/hyphenated.json.want
@@ -1,0 +1,3 @@
+type Foo struct {
+	SearchHistory string `json:"search-history"`
+}


### PR DESCRIPTION
If a JSON field name contains a hyphen, jflect returns an error:

    2015/04/26 10:51:26 1:34: expected ';', found '-' (and 1 more errors)

These commits add a test case for the situation and treat hyphens the same as underscores.